### PR TITLE
fix: better-video-player中，增加鼠标悬停时，字体颜色更改，与智云保持一致

### DIFF
--- a/src/plugins/better-video-player/style.less
+++ b/src/plugins/better-video-player/style.less
@@ -10,6 +10,10 @@
   font-size: 12px;
 }
 
+.mem-bvp-btn:hover {
+  color: #248ef1; /* 鼠标悬停时的字体颜色与智云保持一致 */
+}
+
 .mem-bvt-fullscreen {
   .app-wrap {
     overflow: hidden !important;


### PR DESCRIPTION
hhh，没有悬停提示有点怪怪的